### PR TITLE
include step to set index.html as error document

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ We've provided an example [index.html file][index] you can just copy if you want
 
 * You probably want to put this in an index.html in the root of your s3 bucket
 * You may want to turn on website mode for your s3 bucket.
+* Set both the Index Document and Error Document to index.html.
 * **Note** for s3 buckets in website mode you must explicitly configure the
   bucket url - see below for details and explanation of why this is necessary.
 


### PR DESCRIPTION
It's worth saying that people need to set both the index document and error document to index.html for this to work.
