### PR TITLE
Update list.js to convert "%2F" to "/" in prefix mode

### DIFF
--- a/list.js
+++ b/list.js
@@ -146,6 +146,7 @@ function prepareTable(info) {
       // TODO: need to fix this up for cases where we are on site not bucket
       // in that case href for a file should point to s3 bucket
       item.href = '/' + encodeURIComponent(item.Key);
+      item.href = item.href.replace(/%2F/g, '/');
     }
     var row = renderRow(item, cols);
     content.push(row + '\n');


### PR DESCRIPTION
In prefix mode (var S3BL_IGNORE_PATH = true), encodeURIComponent causes directory paths and %2F to be prefixed to files (see issue #25).
On the example site, http://data.openspending.org/worldbank/cameroon/, the href for Yaounde2.csv file is http://data.openspending.org/worldbank%2Fcameroon%2FYaounde2.csv.
This extra line should fix the issue.
