### PR TITLE
Add S3B_ROOT_DIR variable, rewrite readme

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
   <div id="listing"></div>
 
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
+<script type="text/javascript">
+  // var S3BL_IGNORE_PATH = true;
+  // var BUCKET_URL = 'https://BUCKET.s3-REGION.amazonaws.com';
+  // var S3B_ROOT_DIR = 'SUBDIR_L1/SUBDIR_L2/';
+</script>
 <script src="http://rgrp.github.io/s3-bucket-listing/list.js"></script>
 </body>
 </html>

--- a/list.js
+++ b/list.js
@@ -6,8 +6,8 @@ if (typeof BUCKET_URL == 'undefined') {
   var BUCKET_URL = location.protocol + '//' + location.hostname;
 }
 
-if (typeof S3BL_ROOT_DIR == 'undefined') {
-  var S3BL_ROOT_DIR = '';
+if (typeof S3B_ROOT_DIR == 'undefined') {
+  var S3B_ROOT_DIR = '';
 }
 
 jQuery(function($) {
@@ -55,17 +55,17 @@ function createS3QueryUrl(marker) {
   // buckets but also allow deploying to non-buckets
   //
 
-  var rx = '.*[?&]prefix=' + S3BL_ROOT_DIR + '([^&]+)(&.*)?$';
+  var rx = '.*[?&]prefix=' + S3B_ROOT_DIR + '([^&]+)(&.*)?$';
   var prefix = '';
   if (S3BL_IGNORE_PATH==false) {
-    var prefix = location.pathname.replace(/^\//, S3BL_ROOT_DIR);
+    var prefix = location.pathname.replace(/^\//, S3B_ROOT_DIR);
   }
   var match = location.search.match(rx);
   if (match) {
-    prefix = S3BL_ROOT_DIR + match[1];
+    prefix = S3B_ROOT_DIR + match[1];
   } else {
     if (S3BL_IGNORE_PATH) {
-      var prefix = S3BL_ROOT_DIR;
+      var prefix = S3B_ROOT_DIR;
     }
   }
   if (prefix) {

--- a/list.js
+++ b/list.js
@@ -55,7 +55,7 @@ function createS3QueryUrl(marker) {
   // buckets but also allow deploying to non-buckets
   //
 
-  var rx = /.*[?&]prefix=([^&]+)(&.*)?$/;
+  var rx = '.*[?&]prefix=' + S3BL_ROOT_DIR + '([^&]+)(&.*)?$';
   var prefix = '';
   if (S3BL_IGNORE_PATH==false) {
     var prefix = location.pathname.replace(/^\//, S3BL_ROOT_DIR);

--- a/list.js
+++ b/list.js
@@ -62,7 +62,7 @@ function createS3QueryUrl(marker) {
   }
   var match = location.search.match(rx);
   if (match) {
-    prefix = match[1];
+    prefix = S3BL_ROOT_DIR + match[1];
   } else {
     if (S3BL_IGNORE_PATH) {
       var prefix = S3BL_ROOT_DIR;


### PR DESCRIPTION
Add option (S3B_ROOT_DIR) to set the highest navigable folder.
Rewrite readme to provide 4 different configurations to avoid confusion with settings.

Readme addresses issue #31 
HTTPS only section in readme should address issue #23
Readme also addresses issue #18 - atomicloopzilla needs to put index.html as the error document too
