### PR TITLE
Support both path and virtualhost S3 buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Copy these 3 lines into the HTML file where you want the listing to show up:
     <!-- the JS variables for the listing -->
     <script type="text/javascript">
       // var S3BL_IGNORE_PATH = true;
+      // var BUCKET_NAME = 'BUCKET';
       // var BUCKET_URL = 'https://BUCKET.s3-REGION.amazonaws.com';
       // var S3B_ROOT_DIR = 'SUBDIR_L1/SUBDIR_L2/';
     </script>
@@ -48,6 +49,17 @@ You will have to put the html code in your page html AND your error 404 document
 
 Setting this to true will cause URL navigation to be in this form:
 - _`http://data.openspending.org/index.html?prefix=worldbank/cameroon/`_
+
+
+#### BUCKET_NAME variable
+Valid options = `''` (default) or your _bucket name_, e.g.
+
+`BUCKET`
+
+This option is designed to support access to S3 buckets in non-website mode,
+via both path-style and virtualhost-style urls. See the [Amazon Documentation](
+http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html) for details
+on the difference.
 
 
 #### BUCKET_URL variable
@@ -133,9 +145,9 @@ Mandatory settings:
 Mandatory settings:
 ```
       var S3BL_IGNORE_PATH = true;
+      var BUCKET_NAME = 'BUCKET';
 ```
 - Put _index.html_ in your bucket.
-- Use the _index.html_'s full path to access the script, e.g. _`http://BUCKET.s3-REGION.amazonaws.com/index.html`_
 
 
 ## S3 website bucket permissions

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
 <script type="text/javascript">
   // var S3BL_IGNORE_PATH = true;
+  // var BUCKET_NAME = 'BUCKET';
   // var BUCKET_URL = 'https://BUCKET.s3-REGION.amazonaws.com';
   // var S3B_ROOT_DIR = 'SUBDIR_L1/SUBDIR_L2/';
 </script>

--- a/list.js
+++ b/list.js
@@ -165,8 +165,12 @@ function prepareTable(info) {
       item.href = BUCKET_URL + '/' + encodeURIComponent(item.Key);
       item.href = item.href.replace(/%2F/g, '/');
     }
-    var row = renderRow(item, cols);
-    content.push(row + '\n');
+    // Don't display the row unless keyText length is greater than zero
+    // keyText is zero length for the directory placeholder (because it is categorized as a file)
+    if (item.keyText.length) {
+        var row = renderRow(item, cols);
+        content.push(row + '\n');
+    }
   });
 
   return content.join('');

--- a/list.js
+++ b/list.js
@@ -102,7 +102,7 @@ function getInfoFromS3Data(xml) {
     return {
       Key: item.find('Prefix').text(),
       LastModified: '',
-      Size: '0',
+      Size: 'dir',
       Type: 'directory'
     }
   });
@@ -144,7 +144,7 @@ function prepareTable(info) {
       item = {
         Key: up,
         LastModified: '',
-        Size: '',
+        Size: 'dir',
         keyText: '../',
         href: S3BL_IGNORE_PATH ? '?prefix=' + up : '../'
       },

--- a/list.js
+++ b/list.js
@@ -115,6 +115,7 @@ function getInfoFromS3Data(xml) {
     files: files,
     directories: directories,
     prefix: $(xml.find('Prefix')[0]).text(),
+    bucketname: $(xml.find('Name')).text(),
     nextMarker: encodeURIComponent(nextMarker)
   }
 }
@@ -124,13 +125,16 @@ function getInfoFromS3Data(xml) {
 //    files: ..
 //    directories: ..
 //    prefix: ...
+//    bucketname: ...
 // } 
 function prepareTable(info) {
   var files = info.files.concat(info.directories)
     , prefix = info.prefix
+    , bucketname = info.bucketname
     ;
   var cols = [ 45, 30, 15 ];
   var content = [];
+  content.push('Bucket: ' + bucketname + ', Directory: /' + prefix + '\n');
   content.push(padRight('Last Modified', cols[1]) + '  ' + padRight('Size', cols[2]) + 'Key \n');
   content.push(new Array(cols[0] + cols[1] + cols[2] + 4).join('-') + '\n');
 

--- a/list.js
+++ b/list.js
@@ -6,6 +6,14 @@ if (typeof BUCKET_URL == 'undefined') {
   var BUCKET_URL = location.protocol + '//' + location.hostname;
 }
 
+if (typeof BUCKET_NAME != 'undefined') {
+    // if bucket_url does not start with bucket_name,
+    // assume path-style url
+    if (!~BUCKET_URL.indexof(location.protocol + '//' + BUCKET_NAME)) {
+        BUCKET_URL += '/' + BUCKET_NAME;
+    }
+}
+
 if (typeof S3B_ROOT_DIR == 'undefined') {
   var S3B_ROOT_DIR = '';
 }

--- a/list.js
+++ b/list.js
@@ -9,7 +9,7 @@ if (typeof BUCKET_URL == 'undefined') {
 if (typeof BUCKET_NAME != 'undefined') {
     // if bucket_url does not start with bucket_name,
     // assume path-style url
-    if (!~BUCKET_URL.indexof(location.protocol + '//' + BUCKET_NAME)) {
+    if (!~BUCKET_URL.indexOf(location.protocol + '//' + BUCKET_NAME)) {
         BUCKET_URL += '/' + BUCKET_NAME;
     }
 }


### PR DESCRIPTION
I made a simple change to support both path-style and virtualhost-style urls for S3 buckets, using a new parameter, `BUCKET_NAME`. I did lump in some minor styling changes (wasn't actually planning to open a pull-request, but figured I might as well). I can reorganize the commits if you want to separate things out so it's easier to review.
