### PR TITLE
Add new variable, `BUCKET_NAME`

### DIFF
--- a/list.js
+++ b/list.js
@@ -6,6 +6,14 @@ if (typeof BUCKET_URL == 'undefined') {
   var BUCKET_URL = location.protocol + '//' + location.hostname;
 }
 
+if (typeof BUCKET_NAME != 'undefined') {
+    // if bucket_url does not start with bucket_name,
+    // assume path-style url
+    if (!~BUCKET_URL.indexOf(location.protocol + '//' + BUCKET_NAME)) {
+        BUCKET_URL += '/' + BUCKET_NAME;
+    }
+}
+
 if (typeof S3B_ROOT_DIR == 'undefined') {
   var S3B_ROOT_DIR = '';
 }


### PR DESCRIPTION
This commit adds the `BUCKET_NAME` variable. This variable is used
to support simultaneously both path- and virtualhost- style urls
to the s3 bucket listing, from a single index.html file.
Previously, `BUCKET_URL` could be used to support one method or the
other, but not both methods simultaneously.
