### PR TITLE
Row shading. CSS & Shiny stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Copy these 3 lines into the HTML file where you want the listing to show up:
       // var BUCKET_NAME = 'BUCKET';
       // var BUCKET_URL = 'https://BUCKET.s3-REGION.amazonaws.com';
       // var S3B_ROOT_DIR = 'SUBDIR_L1/SUBDIR_L2/';
+      // var S3B_SORT = 'DEFAULT';
     </script>
 
     <!-- the JS to the do the listing -->
@@ -126,12 +127,27 @@ This variable is optional.  It allows you to modify the host used for link hrefs
 Normally your links will point to `<BUCKET_URL>/<KEY>`.  If specified, your links will point to `<BUCKET_WEBSITE_URL>/<KEY>` (but the list API calls will still use the configured `BUCKET_URL`);
 
 
+### `S3B_SORT` variable
+
+This will sort your bucket listing. Variable options should be self-explanatory.
+
+Valid options:
+
+- `OLD2NEW`
+- `NEW2OLD`
+- `A2Z`
+- `Z2A`
+- `BIG2SMALL`
+- `SMALL2BIG`
+
+
 ## Four Valid Configurations
 
 1. Embed into your website
 2. Use Amazon S3 in website mode with URL navigation
 3. Use Amazon S3 in website mode with prefix mode (ignore_path mode)
 4. Use Amazon S3 in non-website mode
+
 
 
 #### 1. Embed into your website

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Copy these 3 lines into the HTML file where you want the listing to show up:
 
     <div id="listing"></div>
 
-    <!-- add jquery - if you already have it just ignore this line -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
+    <!-- add jQuery - if you already have it just ignore this line -->
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 
     <!-- the JS variables for the listing -->
     <script type="text/javascript">
@@ -28,7 +28,7 @@ Copy these 3 lines into the HTML file where you want the listing to show up:
     </script>
 
     <!-- the JS to the do the listing -->
-    <script src="https://rawgit.com/rgrp/s3-bucket-listing/gh-pages/list.js"></script>
+    <script type="text/javascript" src="https://rawgit.com/rufuspollock/s3-bucket-listing/gh-pages/list.js"></script>
 
 We've provided an example [index.html][index] file you can just copy if you want.
 
@@ -254,7 +254,7 @@ For config 4, navigate to your index.html's full path using https, e.g. _`https:
 To stop browser warnings about displaying insecure content in secure mode:
 - Host the following 3 files in your website/bucket:
   - _list.js_
-  - http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js
+  - https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js
   - http://assets.okfn.org/images/icons/ajaxload-circle.gif
 - Edit _index.html_ to point to your bucket's `jquery.min.js` & `list.js` file (using relative paths)
 - Edit _list.js_ to point to your bucket's `ajaxload-circle.gif`

--- a/S3.css
+++ b/S3.css
@@ -1,0 +1,963 @@
+/*!
+Pure v0.6.1
+Copyright 2013 Yahoo!
+Licensed under the BSD License.
+https://github.com/yahoo/pure/blob/master/LICENSE.md
+*/
+/*!
+
+/*! normalize.css v5.0.0 | MIT License | github.com/necolas/normalize.css */
+
+
+table.shadedTable tr#rowEven {
+   background-color: linen;
+   }
+
+table.shadedTable {
+   background-color: lightgray; 
+   }
+/*
+table.shadedTable * tr:hover, table.shadedTable * tr:active, table.shadedTable * tr:focus {
+    font-weight: bolder;
+}
+*/
+
+table#S3TABLE * tr:hover, table#S3TABLE * tr:active, table#S3TABLE * tr:focus {
+    background-color: rgba(33,150,243,.1);
+}
+
+.button-bl {
+  color: white;
+  border-radius: 4px;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+  background: rgb(66, 184, 221); /* this is a light blue */
+}
+
+
+/**
+ * 1. Change the default font family in all browsers (opinionated).
+ * 2. Correct the line height in all browsers.
+ * 3. Prevent adjustments of font size after orientation changes in
+ *    IE on Windows Phone and in iOS.
+ */
+
+/* Document
+   ========================================================================== */
+
+html {
+  font-family: sans-serif; /* 1 */
+  line-height: 1.15; /* 2 */
+  -ms-text-size-adjust: 100%; /* 3 */
+  -webkit-text-size-adjust: 100%; /* 3 */
+}
+
+/* Sections
+   ========================================================================== */
+
+/**
+ * Remove the margin in all browsers (opinionated).
+ */
+
+body {
+  margin: 0;
+}
+
+/**
+ * Add the correct display in IE 9-.
+ */
+
+article,
+aside,
+footer,
+header,
+nav,
+section {
+  display: block;
+}
+
+/**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 9-.
+ * 1. Add the correct display in IE.
+ */
+
+figcaption,
+figure,
+main { /* 1 */
+  display: block;
+}
+
+/**
+ * Add the correct margin in IE 8.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+pre {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * 1. Remove the gray background on active links in IE 10.
+ * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
+ */
+
+a {
+  background-color: transparent; /* 1 */
+  -webkit-text-decoration-skip: objects; /* 2 */
+}
+
+/**
+ * Remove the outline on focused links when they are also active or hovered
+ * in all browsers (opinionated).
+ */
+
+a:active,
+a:hover {
+  outline-width: 0;
+}
+
+/**
+ * 1. Remove the bottom border in Firefox 39-.
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
+ */
+
+b,
+strong {
+  font-weight: inherit;
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+ * Add the correct font style in Android 4.3-.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Add the correct background and color in IE 9-.
+ */
+
+mark {
+  background-color: #ff0;
+  color: #000;
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in
+ * all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 9-.
+ */
+
+audio,
+video {
+  display: inline-block;
+}
+
+/**
+ * Add the correct display in iOS 4-7.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Remove the border on images inside links in IE 10-.
+ */
+
+img {
+  border-style: none;
+}
+
+/**
+ * Hide the overflow in IE.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * 1. Change the font styles in all browsers (opinionated).
+ * 2. Remove the margin in Firefox and Safari.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: sans-serif; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+ * Show the overflow in IE.
+ * 1. Show the overflow in Edge.
+ */
+
+button,
+input { /* 1 */
+  overflow: visible;
+}
+
+/**
+ * Remove the inheritance of text transform in Edge, Firefox, and IE.
+ * 1. Remove the inheritance of text transform in Firefox.
+ */
+
+button,
+select { /* 1 */
+  text-transform: none;
+}
+
+/**
+ * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
+ *    controls in Android 4.
+ * 2. Correct the inability to style clickable types in iOS and Safari.
+ */
+
+button,
+html [type="button"], /* 1 */
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+}
+
+/**
+ * Remove the inner border and padding in Firefox.
+ */
+
+button::-moz-focus-inner,
+[type="button"]::-moz-focus-inner,
+[type="reset"]::-moz-focus-inner,
+[type="submit"]::-moz-focus-inner {
+  border-style: none;
+  padding: 0;
+}
+
+/**
+ * Restore the focus styles unset by the previous rule.
+ */
+
+button:-moz-focusring,
+[type="button"]:-moz-focusring,
+[type="reset"]:-moz-focusring,
+[type="submit"]:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Change the border, margin, and padding in all browsers (opinionated).
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct the text wrapping in Edge and IE.
+ * 2. Correct the color inheritance from `fieldset` elements in IE.
+ * 3. Remove the padding so developers are not caught out when they zero out
+ *    `fieldset` elements in all browsers.
+ */
+
+legend {
+  box-sizing: border-box; /* 1 */
+  color: inherit; /* 2 */
+  display: table; /* 1 */
+  max-width: 100%; /* 1 */
+  padding: 0; /* 3 */
+  white-space: normal; /* 1 */
+}
+
+/**
+ * 1. Add the correct display in IE 9-.
+ * 2. Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Remove the default vertical scrollbar in IE.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * 1. Add the correct box sizing in IE 10-.
+ * 2. Remove the padding in IE 10-.
+ */
+
+[type="checkbox"],
+[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Correct the cursor style of increment and decrement buttons in Chrome.
+ */
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Correct the odd appearance in Chrome and Safari.
+ * 2. Correct the outline style in Safari.
+ */
+
+[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+ * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
+ */
+
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * 1. Correct the inability to style clickable types in iOS and Safari.
+ * 2. Change font properties to `inherit` in Safari.
+ */
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/* Interactive
+   ========================================================================== */
+
+/*
+ * Add the correct display in IE 9-.
+ * 1. Add the correct display in Edge, IE, and Firefox.
+ */
+
+details, /* 1 */
+menu {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+summary {
+  display: list-item;
+}
+
+/* Scripting
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 9-.
+ */
+
+canvas {
+  display: inline-block;
+}
+
+/**
+ * Add the correct display in IE.
+ */
+
+template {
+  display: none;
+}
+
+/* Hidden
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 10-.
+ */
+
+[hidden] {
+  display: none;
+}
+
+/*****************************/
+/**** PURE CSS STARTS HERE****/
+/*****************************/
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
+ */
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * Improve readability of focused elements when they are also in an
+ * active/hover state.
+ */
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+
+b,
+strong {
+  font-weight: bold;
+}
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Address styling not present in IE 8/9.
+ */
+
+mark {
+  background: #ff0;
+  color: #000;
+}
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+
+img {
+  border: 0;
+}
+
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * Address differences between Firefox and other browsers.
+ */
+
+hr {
+  box-sizing: content-box;
+  height: 0;
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit; /* 1 */
+  font: inherit; /* 2 */
+  margin: 0; /* 3 */
+}
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+
+button,
+select {
+  text-transform: none;
+}
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+
+button,
+html input[type="button"], /* 1 */
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
+}
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+input {
+  line-height: normal;
+}
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield; /* 1 */
+  box-sizing: content-box; /* 2 */
+}
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+
+optgroup {
+  font-weight: bold;
+}
+
+/* Tables
+   ========================================================================== */
+
+/**
+ * Remove most spacing between table cells.
+ */
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+td,
+th {
+  padding: 0;
+}
+
+/*csslint important:false*/
+
+/* ==========================================================================
+   Pure Base Extras
+   ========================================================================== */
+
+/**
+ * Extra rules that Pure adds on top of Normalize.css
+ */
+
+/**
+ * Always hide an element when it has the `hidden` HTML attribute.
+ */
+
+.hidden,
+[hidden] {
+    display: none !important;
+}
+
+/**
+ * Add this class to an image to make it fit within it's fluid parent wrapper while maintaining
+ * aspect ratio.
+ */
+.pure-img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+}
+
+
+/* Pure CSS Tables Starts Here*/
+.pure-table {
+    /* Remove spacing between table cells (from Normalize.css) */
+    border-collapse: collapse;
+    border-spacing: 0;
+    empty-cells: show;
+    border: 1px solid #cbcbcb;
+}
+
+.pure-table caption {
+    color: #000;
+    font: italic 85%/1 arial, sans-serif;
+    padding: 1em 0;
+    text-align: center;
+}
+
+.pure-table td,
+.pure-table th {
+    border-left: 1px solid #cbcbcb;/*  inner column border */
+    border-width: 0 0 0 1px;
+    font-size: inherit;
+    margin: 0;
+    overflow: visible; /*to make ths where the title is really long work*/
+    padding: 0.5em 1em; /* cell padding */
+}
+
+/* Consider removing this next declaration block, as it causes problems when
+there's a rowspan on the first cell. Case added to the tests. issue#432 */
+.pure-table td:first-child,
+.pure-table th:first-child {
+    border-left-width: 0;
+}
+
+.pure-table thead {
+    background-color: #e0e0e0;
+    color: #000;
+    text-align: left;
+    vertical-align: bottom;
+}
+
+/*
+striping:
+   even - #fff (white)
+   odd  - #f2f2f2 (light gray)
+*/
+.pure-table td {
+    background-color: transparent;
+}
+.pure-table-odd td {
+    background-color: #f2f2f2;
+}
+
+/*FB: Slight mod so we're not setting TD background. Afterall... 
+if the browser supports this, it will support tr backgrounds.*/
+/* nth-child selector for modern browsers */
+/*.pure-table-striped tr:nth-child(2n-1) td {*/
+.pure-table-striped tr:nth-child(2n-1) {
+    background-color: #f2f2f2;
+}
+
+/* BORDERED TABLES */
+.pure-table-bordered td {
+    border-bottom: 1px solid #cbcbcb;
+}
+.pure-table-bordered tbody > tr:last-child > td {
+    border-bottom-width: 0;
+}
+
+
+/* HORIZONTAL BORDERED TABLES */
+
+.pure-table-horizontal td,
+.pure-table-horizontal th {
+    /* border-width: 8px 11px 19px 6px; */
+    border-bottom: 1px solid #cbcbcb;
+}
+.pure-table-horizontal tbody > tr:last-child > td {
+    border-bottom-width: 0;
+}
+

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   // var BUCKET_NAME = 'BUCKET';
   // var BUCKET_URL = 'https://BUCKET.s3.amazonaws.com';
   // var S3B_ROOT_DIR = 'SUBDIR_L1/SUBDIR_L2/';
+  // var S3B_SORT = 'DEFAULT';
 </script>
 <script type="text/javascript" src="https://rawgit.com/rufuspollock/s3-bucket-listing/gh-pages/list.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -1,17 +1,19 @@
+<!DOCTYPE html>
 <html>
 <head>
+  <title>S3 Bucket Listing Generator</title>
 </head>
 <body>
   <div id="navigation"></div>
   <div id="listing"></div>
-
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
+  
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 <script type="text/javascript">
   // var S3BL_IGNORE_PATH = true;
   // var BUCKET_NAME = 'BUCKET';
   // var BUCKET_URL = 'https://BUCKET.s3.amazonaws.com';
   // var S3B_ROOT_DIR = 'SUBDIR_L1/SUBDIR_L2/';
 </script>
-<script src="https://rawgit.com/rufuspollock/s3-bucket-listing/gh-pages/list.js"></script>
+<script type="text/javascript" src="https://rawgit.com/rufuspollock/s3-bucket-listing/gh-pages/list.js"></script>
 </body>
 </html>

--- a/list.js
+++ b/list.js
@@ -1,4 +1,4 @@
-if (typeof S3BL_IGNORE_PATH == 'undefined' || S3BL_IGNORE_PATH!=true) {
+if (typeof S3BL_IGNORE_PATH == 'undefined' || S3BL_IGNORE_PATH != true) {
   var S3BL_IGNORE_PATH = false;
 }
 
@@ -7,11 +7,11 @@ if (typeof BUCKET_URL == 'undefined') {
 }
 
 if (typeof BUCKET_NAME != 'undefined') {
-    // if bucket_url does not start with bucket_name,
-    // assume path-style url
-    if (!~BUCKET_URL.indexOf(location.protocol + '//' + BUCKET_NAME)) {
-        BUCKET_URL += '/' + BUCKET_NAME;
-    }
+  // if bucket_url does not start with bucket_name,
+  // assume path-style url
+  if (!~BUCKET_URL.indexOf(location.protocol + '//' + BUCKET_NAME)) {
+    BUCKET_URL += '/' + BUCKET_NAME;
+  }
 }
 
 if (typeof BUCKET_WEBSITE_URL == 'undefined') {
@@ -22,47 +22,50 @@ if (typeof S3B_ROOT_DIR == 'undefined') {
   var S3B_ROOT_DIR = '';
 }
 
-jQuery(function($) {
-  getS3Data();
-});
+jQuery(function($) { getS3Data(); });
 
 function getS3Data(marker, html) {
   var s3_rest_url = createS3QueryUrl(marker);
   // set loading notice
-  $('#listing').html('<img src="//assets.okfn.org/images/icons/ajaxload-circle.gif" />');
+  $('#listing')
+      .html('<img src="//assets.okfn.org/images/icons/ajaxload-circle.gif" />');
   $.get(s3_rest_url)
-    .done(function(data) {
-      // clear loading notice
-      $('#listing').html('');
-      var xml = $(data);
-      var info = getInfoFromS3Data(xml);
+      .done(function(data) {
+        // clear loading notice
+        $('#listing').html('');
+        var xml = $(data);
+        var info = getInfoFromS3Data(xml);
 
-      buildNavigation(info)
+        buildNavigation(info);
 
-      html = typeof html !== 'undefined' ? html + prepareTable(info) : prepareTable(info);
-      if (info.nextMarker != "null") {
-        getS3Data(info.nextMarker, html);
-      } else {
-        document.getElementById('listing').innerHTML = '<pre>' + html + '</pre>';
-      }
-    })
-    .fail(function(error) {
-      console.error(error);
-      $('#listing').html('<strong>Error: ' + error + '</strong>');
-    });
+        html = typeof html !== 'undefined' ? html + prepareTable(info) :
+                                             prepareTable(info);
+        if (info.nextMarker != "null") {
+          getS3Data(info.nextMarker, html);
+        } else {
+          document.getElementById('listing').innerHTML =
+              '<pre>' + html + '</pre>';
+        }
+      })
+      .fail(function(error) {
+        console.error(error);
+        $('#listing').html('<strong>Error: ' + error + '</strong>');
+      });
 }
 
 function buildNavigation(info) {
-  var root = '<a href="?prefix=">' + BUCKET_WEBSITE_URL + '</a> / '
+  var root = '<a href="?prefix=">' + BUCKET_WEBSITE_URL + '</a> / ';
   if (info.prefix) {
-    var processedPathSegments = ''
-    var content = $.map(info.prefix.split('/'), function(pathSegment){
-      processedPathSegments = processedPathSegments + encodeURIComponent(pathSegment) + '/'
-      return '<a href="?prefix=' + processedPathSegments + '">' + pathSegment + '</a>'
+    var processedPathSegments = '';
+    var content = $.map(info.prefix.split('/'), function(pathSegment) {
+      processedPathSegments =
+          processedPathSegments + encodeURIComponent(pathSegment) + '/';
+      return '<a href="?prefix=' + processedPathSegments + '">' + pathSegment +
+             '</a>';
     });
-    $('#navigation').html(root + content.join(' / '))
+    $('#navigation').html(root + content.join(' / '));
   } else {
-    $('#navigation').html(root)
+    $('#navigation').html(root);
   }
 }
 
@@ -86,7 +89,7 @@ function createS3QueryUrl(marker) {
 
   var rx = '.*[?&]prefix=' + S3B_ROOT_DIR + '([^&]+)(&.*)?$';
   var prefix = '';
-  if (S3BL_IGNORE_PATH==false) {
+  if (S3BL_IGNORE_PATH == false) {
     var prefix = location.pathname.replace(/^\//, S3B_ROOT_DIR);
   }
   var match = location.search.match(rx);
@@ -113,9 +116,9 @@ function getInfoFromS3Data(xml) {
     item = $(item);
     return {
       Key: item.find('Key').text(),
-      LastModified: item.find('LastModified').text(),
-      Size: bytesToHumanReadable(item.find('Size').text()),
-      Type: 'file'
+          LastModified: item.find('LastModified').text(),
+          Size: bytesToHumanReadable(item.find('Size').text()),
+          Type: 'file'
     }
   });
   var directories = $.map(xml.find('CommonPrefixes'), function(item) {
@@ -147,25 +150,26 @@ function getInfoFromS3Data(xml) {
 //    prefix: ...
 // }
 function prepareTable(info) {
-  var files = info.files.concat(info.directories)
-    , prefix = info.prefix
-    ;
-  var cols = [ 45, 30, 15 ];
+  var files = info.files.concat(info.directories), prefix = info.prefix;
+  var cols = [45, 30, 15];
   var content = [];
-  content.push(padRight('Last Modified', cols[1]) + '  ' + padRight('Size', cols[2]) + 'Key \n');
+  content.push(padRight('Last Modified', cols[1]) + '  ' +
+               padRight('Size', cols[2]) + 'Key \n');
   content.push(new Array(cols[0] + cols[1] + cols[2] + 4).join('-') + '\n');
 
-  // add the ../ at the start of the directory listing, unless when at the root dir already
+  // add ../ at the start of the dir listing, unless we are already at the root dir
   if (prefix && prefix !== S3B_ROOT_DIR) {
-    var up = prefix.replace(/\/$/, '').split('/').slice(0, -1).concat('').join('/'), // one directory up
-      item = {
-        Key: up,
-        LastModified: '',
-        Size: '',
-        keyText: '../',
-        href: S3BL_IGNORE_PATH ? '?prefix=' + up : '../'
-      },
-      row = renderRow(item, cols);
+    var up = prefix.replace(/\/$/, '').split('/').slice(0, -1).concat('').join(
+            '/'),  // one directory up
+        item =
+            {
+              Key: up,
+              LastModified: '',
+              Size: '',
+              keyText: '../',
+              href: S3BL_IGNORE_PATH ? '?prefix=' + up : '../'
+            },
+        row = renderRow(item, cols);
     content.push(row + '\n');
   }
 
@@ -174,7 +178,8 @@ function prepareTable(info) {
     item.keyText = item.Key.substring(prefix.length);
     if (item.Type === 'directory') {
       if (S3BL_IGNORE_PATH) {
-        item.href = location.protocol + '//' + location.hostname + location.pathname + '?prefix=' + item.Key;
+        item.href = location.protocol + '//' + location.hostname +
+                    location.pathname + '?prefix=' + item.Key;
       } else {
         item.href = item.keyText;
       }
@@ -198,7 +203,7 @@ function renderRow(item, cols) {
 }
 
 function padRight(padString, length) {
-  var str = padString.slice(0, length-3);
+  var str = padString.slice(0, length - 3);
   if (padString.length > str.length) {
     str += '...';
   }


### PR DESCRIPTION
## This consists primarily of implementing shading & other visual enhancments
- This is **part 3 of 3** of multiple pull requests as requested by @rufuspollock in #59 

### Cell Shading

This consisted of changing a few things
1. `S3.css` Has been added
2. Added a few buttons to the listing and attached a couple of listeners to it
3. Rewrote the current `renerRow` w/ __<span>__ implementation, and replaced it with __tables__. This also means I could remove several other pieces of code. It still needs considerable cleanup of existing code.


This has two buttons currently added. 
- `my cell shading`:  My implmentation of the cell shading.
1. More complex, requires more math processing(neglabible)
2. Dirty: Each row is assigned a class of `rowOdd` or `rowEven`
- `ez cell shading`: Uses a simple CSS selector. 
1. Wasting my time... (I wrote my code before discovering this already there waiting for me. Duh!)
2. Easily configurable via css, applied with a single class toggle


## TODO
1. Which implementation to use? I want to say `ez` is the way to go. Thoughts?
2. Suggestions or prefrences or specific coloring?
3. Can we enable it by default?
4. Where to stick button/link to toggle row shading?


### `clang-format` and formatting
I use __clang-format__ for most of my code based on the '_Google API_'.
The following are the settings used:

```---
Language: JavaScript
BasedOnStyle: Google
# Use 100 columns for JS.
ColumnLimit: 100
```
