### PR TITLE
add support for EXCLUDE_FILE option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Copy these 3 lines into the HTML file where you want the listing to show up:
       // var BUCKET_URL = 'https://BUCKET.s3-REGION.amazonaws.com';
       // var S3B_ROOT_DIR = 'SUBDIR_L1/SUBDIR_L2/';
       // var S3B_SORT = 'DEFAULT';
+      // var EXCLUDE_FILE = 'index.html';
     </script>
 
     <!-- the JS to the do the listing -->
@@ -139,6 +140,11 @@ Valid options:
 - `Z2A`
 - `BIG2SMALL`
 - `SMALL2BIG`
+
+
+### `EXCLUDE_FILE` variable
+
+This variable is optional.  It allows you to exclude a file (e.g. index.html) from the file listings.
 
 
 ## Four Valid Configurations

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Copy these 3 lines into the HTML file where you want the listing to show up:
       // var S3B_ROOT_DIR = 'SUBDIR_L1/SUBDIR_L2/';
       // var S3B_SORT = 'DEFAULT';
       // var EXCLUDE_FILE = 'index.html';
+      // var AUTO_TITLE = true;
     </script>
 
     <!-- the JS to the do the listing -->
@@ -145,6 +146,11 @@ Valid options:
 ### `EXCLUDE_FILE` variable
 
 This variable is optional.  It allows you to exclude a file (e.g. index.html) from the file listings.
+
+
+### `AUTO_TITLE` variable
+
+This variable is optional.  It allows you to automatically set the title.
 
 
 ## Four Valid Configurations

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   // var BUCKET_URL = 'https://BUCKET.s3.amazonaws.com';
   // var S3B_ROOT_DIR = 'SUBDIR_L1/SUBDIR_L2/';
   // var S3B_SORT = 'DEFAULT';
+  // var EXCLUDE_FILE = 'index.html';
 </script>
 <script type="text/javascript" src="https://rawgit.com/rufuspollock/s3-bucket-listing/gh-pages/list.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   // var S3B_ROOT_DIR = 'SUBDIR_L1/SUBDIR_L2/';
   // var S3B_SORT = 'DEFAULT';
   // var EXCLUDE_FILE = 'index.html';
+  // var AUTO_TITLE = true;
 </script>
 <script type="text/javascript" src="https://rawgit.com/rufuspollock/s3-bucket-listing/gh-pages/list.js"></script>
 </body>

--- a/list.js
+++ b/list.js
@@ -226,7 +226,8 @@ function prepareTable(info) {
       item.href = item.href.replace(/%2F/g, '/');
     }
     var row = renderRow(item, cols);
-    content.push(row + '\n');
+    if (typeof EXCLUDE_FILE == 'undefined' || EXCLUDE_FILE != item.Key)
+      content.push(row + '\n');
   });
 
   return content.join('');

--- a/list.js
+++ b/list.js
@@ -1,3 +1,7 @@
+if (typeof AUTO_TITLE != 'undefined' && AUTO_TITLE == true) {
+  document.title = location.hostname;
+}
+
 if (typeof S3BL_IGNORE_PATH == 'undefined' || S3BL_IGNORE_PATH != true) {
   var S3BL_IGNORE_PATH = false;
 }


### PR DESCRIPTION
This commit adds support for a new EXCLUDE_FILE option so that you can chose to exclude (e.g.) the index.html file from the listings, and the second commit adds support for a new AUTO_TITLE option to automatically set the <title> header.  (so I can upload the same index.html file to many buckets)