### PR TITLE
Enable exclusion of multipe files

### DIFF
--- a/list.js
+++ b/list.js
@@ -235,7 +235,7 @@ function prepareTable(info) {
       item.href = item.href.replace(/%2F/g, '/');
     }
     var row = renderRow(item, cols);
-    if (typeof EXCLUDE_FILE == 'undefined' || EXCLUDE_FILE != item.Key)
+    if (typeof EXCLUDE_FILE == 'undefined' || EXCLUDE_FILE.indexOf(item.Key) < 0)
       content.push(row + '\n');
   });
 


### PR DESCRIPTION
Handy when using https mode and you want to avoid browser warnings by publishing the .gif and .js on the bucket.