### PR TITLE
switch from depreciated rawgit.com to github.io, and add navigation div to README.md

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
 <body>
   <div id="listing"></div>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
-<script src="https://raw.github.com/rgrp/s3-bucket-listing/master/list.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
+<script src="https://rgrp.github.io/s3-bucket-listing/list.js"></script>
 </body>
 </html>
 


### PR DESCRIPTION
rawgit.com is shutting down in October 2019, switched URLs to use github.io.

updated README.md, and added docs for new navigation div.
