### PR TITLE
fix(js): Switch to protocol-relative URL

### DIFF
--- a/list.js
+++ b/list.js
@@ -3,7 +3,7 @@ if (typeof AUTO_TITLE != 'undefined' && AUTO_TITLE == true) {
 }
 
 if (typeof S3_REGION != 'undefined') {
-  var BUCKET_URL = 'http://' + location.hostname + '.' + S3_REGION + '.amazonaws.com'; // e.g. just 's3' for us-east-1 region
+  var BUCKET_URL = '//' + location.hostname + '.' + S3_REGION + '.amazonaws.com'; // e.g. just 's3' for us-east-1 region
   var BUCKET_WEBSITE_URL = location.protocol + '//' + location.hostname;
 }
 


### PR DESCRIPTION
We shouldn't have a hard-coded reference to http in 2019. That's no good. And I suspect that just swapping over to `https` will give people consternation. So, use a [protocol-relative url](https://www.paulirish.com/2010/the-protocol-relative-url/), and let the user's location decide. Should be fine.

Fixes #82.