### PR TITLE
Handle generated links with no trailing slash

### DIFF
--- a/list.js
+++ b/list.js
@@ -138,6 +138,12 @@ function getS3Data(marker, html) {
 
         buildNavigation(info);
 
+        // Add a <base> element to the document head to make relative links
+        // work even if the URI does not contain a trailing slash
+        var base = window.location.href
+        base = (base.endsWith('/')) ? base : base + '/';
+        $('head').append('<base href="' + base + '">');
+
         html = typeof html !== 'undefined' ? html + prepareTable(info) :
                                              prepareTable(info);
         if (info.nextMarker != "null") {


### PR DESCRIPTION
#### The issue

If you go to the live demo site for this repo linked from the `README`, http://data.openspending.org/datasets (notice there's _no_ trailing slash), then the relative links generated will link relative to the domain root (`http://data.openspending.org/` in this case), producing incorrect links like `http://data.openspending.org/abc/` instead of `http://data.openspending.org/datasets/abc/`.

However, http://data.openspending.org/datasets/ (_with_ a trailing slash), works just fine since the links are all relative to the path given.

#### The proposed fix

All I've done to try and address this is to add a dynamic `<base>` element into the `<head>` created by looking at the current URI that has a trailing slash so that the links are always produced relative to the current page, not relative to whatever the root may be.

**Edit:** I'm happy to have my contribution licensed under the existing MIT license of this project (as specified at https://github.com/rufuspollock/s3-bucket-listing#copyright-and-license)