### PR TITLE
list.js: Encode directory URL in links

### DIFF
--- a/list.js
+++ b/list.js
@@ -287,7 +287,7 @@ function prepareTable(info) {
         item.href = location.protocol + '//' + location.hostname +
                     location.pathname + '?prefix=' + encodePath(item.Key);
       } else {
-        item.href = item.keyText;
+        item.href = encodePath(item.keyText);
       }
     } else {
       item.href = BUCKET_WEBSITE_URL + '/' + encodePath(item.Key);


### PR DESCRIPTION
Google Chrome trips over URLs with colons, for example, reporting
"about:blank#blocked". Fix the issue by encoding the URLs to directories
as well.