### PR TITLE
Respect S3BL_IGNORE_PATH when building navigation

### DIFF
--- a/list.js
+++ b/list.js
@@ -160,14 +160,15 @@ function getS3Data(marker, html) {
 }
 
 function buildNavigation(info) {
-  var root = '<a href="?prefix=">' + BUCKET_WEBSITE_URL + '</a> / ';
+  var baseUrl = S3BL_IGNORE_PATH == false ? '/' : '?prefix=';
+  var root = '<a href="' + baseUrl + '">' + BUCKET_WEBSITE_URL + '</a> / ';
   if (info.prefix) {
     var processedPathSegments = '';
     var content = $.map(info.prefix.split('/'), function(pathSegment) {
       processedPathSegments =
           processedPathSegments + encodeURIComponent(pathSegment) + '/';
-      return '<a href="?prefix=' + processedPathSegments + '">' + pathSegment +
-             '</a>';
+      return '<a href="' + baseUrl + processedPathSegments + '">' +
+             pathSegment + '</a>';
     });
     $('#navigation').html(root + content.join(' / '));
   } else {


### PR DESCRIPTION
This change causes URLs for items in the breadcrumb navigation to be generated as absolute URLs with no `prefix` GET parameter when `S3BL_IGNORE_PATH` is `false`.

Previously, the navigation breadcrumbs always generated `?prefix=`-style URLs. In conjunction with `S3BL_IGNORE_PATH = false`, navigating back and forth between a child pseudo-directory and its parent could lead to infinitely deep nested navigation. And, the root breadcrumb item would never actually work.

For example, given a bucket with the directory structure `a/b/`:

1. From the bucket root, navigate into directory `a/` via the file listing.
2. Attempt to navigate back to the bucket root via the first breadcrumb item.

Expected behaviour: the root of the bucket is loaded.
Actual behaviour: the contents of `a/` are reloaded.

1. Starting from scratch, navigate into directory `a/` via the file listing.
2. Navigate into directory `b/` via the file listing.
3. Navigate back to directory `a/` via breadcrumb navigation.
4. Navigate into directory `b/` again via the file listing.

Expected behaviour: the contents of `b/` are loaded, and the breadcrumb navigation shows “root / a / b /”.
Actual behaviour: an empty file listing is shown, and the breadcrumb navigation shows “root / a / b / b /”. Furthermore, you can navigate back and forth between `a/` (via breadcrumb) and `b/` (via the listing) as many times as you like to repeat the number of instances of “b /” at the end of the breadcrumb navigation.