### PR TITLE
Switch CORS policy rules to use JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,13 +275,20 @@ You must setup the S3 website bucket to allow public read access.
 * Assign the following CORS policy
 
 ```
-<CORSConfiguration>
- <CORSRule>
-   <AllowedOrigin>*</AllowedOrigin>
-   <AllowedMethod>GET</AllowedMethod>
-   <AllowedHeader>*</AllowedHeader>
- </CORSRule>
-</CORSConfiguration>
+[
+    {
+        "AllowedHeaders": [
+            "*"
+        ],
+        "AllowedMethods": [
+            "GET"
+        ],
+        "AllowedOrigins": [
+            "*"
+        ],
+        "ExposeHeaders": []
+    }
+]
 ```
 
 


### PR DESCRIPTION
Since the new S3 console only accepts JSON format for settings the CORS policy I've updated the example with the policy I had to use. See https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html for more information.