### PR TITLE
Add port in url when using S3BL_IGNORE_PATH

### DIFF
--- a/list.js
+++ b/list.js
@@ -297,7 +297,7 @@ function prepareTable(info) {
     item.keyText = item.Key.substring(prefix.length);
     if (item.Type === 'directory') {
       if (S3BL_IGNORE_PATH) {
-        item.href = location.protocol + '//' + location.hostname +
+        item.href = location.origin +
                     location.pathname + '?prefix=' + encodePath(item.Key);
       } else {
         item.href = encodePath(item.keyText);


### PR DESCRIPTION
Currently if the script is hosted on `http://localhost:8080/index.html` with `S3BL_IGNORE_PATH` enabled  it incorrectly constructs a URL without the `:8080`

Switch to using `location.origin` which is `location.protocol + '//' + location.hostname + ':' + location.port`