### PR TITLE
Stop S3 marker from being double encoded

### DIFF
--- a/list.js
+++ b/list.js
@@ -215,7 +215,7 @@ function createS3QueryUrl(marker) {
     s3_rest_url += '&prefix=' + encodePath(prefix);
   }
   if (marker) {
-    s3_rest_url += '&marker=' + encodeURIComponent(marker);
+    s3_rest_url += '&marker=' + marker;
   }
   return s3_rest_url;
 }


### PR DESCRIPTION
Currently `nextMarker` is encoded `encodeURIComponent` when returned by `getInfoFromS3Data` but changed in https://github.com/rufuspollock/s3-bucket-listing/commit/4e1700960d297d5497a3a1a49794371e6f3f75c6 causes it to be double encoded when used as the `marker` for next pages. The result is an infinite `getInfoFromS3Data` loop trying to successfully get the next page from S3 api.

Partial revert of https://github.com/rufuspollock/s3-bucket-listing/commit/4e1700960d297d5497a3a1a49794371e6f3f75c6 to stop the faulty double encoding.