### PR TITLE
feat: add option to fetch last modfiied for directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Copy these 4 lines into the HTML file where you want the listing to show up:
       // var BUCKET_URL = 'https://BUCKET.s3-REGION.amazonaws.com';
       // var S3B_ROOT_DIR = 'SUBDIR_L1/SUBDIR_L2/';
       // var S3B_SORT = 'DEFAULT';
+      // var S3B_STAT_DIRS = false;
       // var EXCLUDE_FILE = 'index.html';  // change to array to exclude multiple files
       // var AUTO_TITLE = true;
       // var S3_REGION = 's3'; // for us-east-1
@@ -137,6 +138,11 @@ Valid options:
 - `Z2A`
 - `BIG2SMALL`
 - `SMALL2BIG`
+
+
+### `S3B_STAT_DIRS` variable
+
+This will obtain last modified information for directories at the cost of an additional request made per directory. Variable is a boolean.
 
 
 ### `EXCLUDE_FILE` variable

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   // var BUCKET_URL = 'https://BUCKET.s3.amazonaws.com';
   // var S3B_ROOT_DIR = 'SUBDIR_L1/SUBDIR_L2/';
   // var S3B_SORT = 'DEFAULT';
+  // var S3B_STAT_DIRS = false;
   // var EXCLUDE_FILE = 'index.html';  // change to array to exclude multiple files, regexp also supported e.g. /^(.*\/)?index.html$/ to exclude all index.html
   // var AUTO_TITLE = true;
   // var S3_REGION = 's3'; // for us-east-1

--- a/list.js
+++ b/list.js
@@ -35,6 +35,10 @@ if (typeof S3B_SORT == 'undefined') {
   var S3B_SORT = 'DEFAULT';
 }
 
+if (typeof S3B_STAT_DIRS == 'undefined' || S3B_STAT_DIRS != true) {
+  var S3B_STAT_DIRS = false;
+}
+
 if (typeof EXCLUDE_FILE == 'undefined') {
   var EXCLUDE_FILE = [];
 } else if (typeof EXCLUDE_FILE == 'string' || EXCLUDE_FILE instanceof RegExp) {
@@ -238,10 +242,17 @@ function getInfoFromS3Data(xml) {
   }
   var directories = $.map(xml.find('CommonPrefixes'), function(item) {
     item = $(item);
+    last_modified = '';
+    if (S3B_STAT_DIRS) {
+        http = new XMLHttpRequest();
+        http.open("HEAD",item.find('Prefix').text(),false);
+        http.send();
+        last_modified = (new Date(http.getResponseHeader("Last-Modified"))).toISOString();
+    }
     // clang-format off
     return {
       Key: item.find('Prefix').text(),
-        LastModified: '',
+        LastModified: last_modified,
         Size: '0',
         Type: 'directory'
     }


### PR DESCRIPTION
Desired outcome is to have "Last Modified" information visible. The existing network call with CommonPrefix does not have this. Options are to do a full recursive listing in a single call, or to stat each directory one by one.
 
This means additional network requests, so the default is false.

Sync XHR was easy, but making it async is feasible if needed.