### PR TITLE
chore: Remove dependency on jQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@ Copy these 4 lines into the HTML file where you want the listing to show up:
     <div id="navigation"></div>
     <div id="listing"></div>
 
-    <!-- add jQuery - if you already have it just ignore this line -->
-    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-
     <!-- the JS variables for the listing -->
     <script type="text/javascript">
       // var S3BL_IGNORE_PATH = true;
@@ -332,9 +329,8 @@ For config 4, navigate to your index.html's full path using https, e.g. _`https:
 To stop browser warnings about displaying insecure content in secure mode:
 - Host the following 3 files in your website/bucket:
   - _list.js_
-  - https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js
   - http://assets.okfn.org/images/icons/ajaxload-circle.gif
-- Edit _index.html_ to point to your bucket's `jquery.min.js` & `list.js` file (using relative paths)
+- Edit _index.html_ to point to your bucket's `list.js` file (using relative paths)
 - Edit _list.js_ to point to your bucket's `ajaxload-circle.gif`
 
 With config 4, you will then be utilising AmazonAWS' wildcard SSL (unfortunately it is SHA1 only).

--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
   <div id="navigation"></div>
   <div id="listing"></div>
 
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
 <script type="text/javascript">
   // var S3BL_IGNORE_PATH = true;
   // var BUCKET_NAME = 'BUCKET';

--- a/list.js
+++ b/list.js
@@ -45,59 +45,7 @@ if (typeof EXCLUDE_FILE == 'undefined') {
   var EXCLUDE_FILE = [EXCLUDE_FILE];
 }
 
-// https://tc39.github.io/ecma262/#sec-array.prototype.includes
-if (!Array.prototype.includes) {
-  Object.defineProperty(Array.prototype, 'includes', {
-    value: function(searchElement, fromIndex) {
-
-      if (this == null) {
-        throw new TypeError('"this" is null or not defined');
-      }
-
-      // 1. Let O be ? ToObject(this value).
-      var o = Object(this);
-
-      // 2. Let len be ? ToLength(? Get(O, "length")).
-      var len = o.length >>> 0;
-
-      // 3. If len is 0, return false.
-      if (len === 0) {
-        return false;
-      }
-
-      // 4. Let n be ? ToInteger(fromIndex).
-      //    (If fromIndex is undefined, this step produces the value 0.)
-      var n = fromIndex | 0;
-
-      // 5. If n ≥ 0, then
-      //  a. Let k be n.
-      // 6. Else n < 0,
-      //  a. Let k be len + n.
-      //  b. If k < 0, let k be 0.
-      var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
-
-      function sameValueZero(x, y) {
-        return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
-      }
-
-      // 7. Repeat, while k < len
-      while (k < len) {
-        // a. Let elementK be the result of ? Get(O, ! ToString(k)).
-        // b. If SameValueZero(searchElement, elementK) is true, return true.
-        if (sameValueZero(o[k], searchElement)) {
-          return true;
-        }
-        // c. Increase k by 1. 
-        k++;
-      }
-
-      // 8. Return false
-      return false;
-    }
-  });
-}
-
-jQuery(function($) { getS3Data(); });
+document.addEventListener('DOMContentLoaded', () => getS3Data());
 
 // This will sort your file listing by most recently modified.
 // Flip the comparator to '>' if you want oldest files first.
@@ -120,49 +68,47 @@ function sortFunction(a, b) {
 
 function getS3Data(marker, prev) {
   var s3_rest_url = createS3QueryUrl(marker);
+  const listing_element = document.getElementById('listing');
   // set loading notice
-  $('#listing')
-      .html('<img src="//assets.okfn.org/images/icons/ajaxload-circle.gif" />');
-  $.get(s3_rest_url)
-      .done(function(data) {
-        // clear loading notice
-        $('#listing').html('');
-        var xml = $(data);
-        var info = getInfoFromS3Data(xml);
+  listing_element.innerHTML =
+    '<img src="//assets.okfn.org/images/icons/ajaxload-circle.gif" />';
 
-        buildNavigation(info);
+  fetch(s3_rest_url)
+    .then(response => response.text())
+    .then(data => {
+      // Clear loading notice
+      listing_element.innerText = '';
+      var parser = new DOMParser();
+      var xml = parser.parseFromString(data, "text/xml");
+      var info = getInfoFromS3Data(xml);
+      buildNavigation(info);
+      // Add a <base> element to the document head
+      var base = window.location.href;
+      base = base.endsWith('/') ? base : base + '/';
+      var baseElement = document.createElement('base');
+      baseElement.href = base;
+      document.head.appendChild(baseElement);
 
-        // Add a <base> element to the document head to make relative links
-        // work even if the URI does not contain a trailing slash
-        var base = window.location.href
-        base = (base.endsWith('/')) ? base : base + '/';
-        $('head').append('<base href="' + base + '">');
-
-        if (typeof prev !== 'undefined') {
-          info.files = info.files.concat(prev.files)
-          info.directories = info.directories.concat(prev.directories)
+      if (typeof prev !== 'undefined') {
+        info.files = info.files.concat(prev.files);
+        info.directories = info.directories.concat(prev.directories);
+      }
+      if (info.nextMarker !== null) {
+        getS3Data(info.nextMarker, info);
+      } else {
+        if (S3B_SORT !== 'DEFAULT') {
+          info.files.sort(sortFunction);
+          info.directories.sort(sortFunction);
         }
-
-        if (info.nextMarker != "null") {
-          getS3Data(info.nextMarker, info);
-        } else {
-          // Slight modification by FuzzBall03
-          // This will sort your file listing based on var S3B_SORT
-          // See url for example:
-          // http://esp-link.s3-website-us-east-1.amazonaws.com/
-          if (S3B_SORT != 'DEFAULT') {
-            info.files.sort(sortFunction);
-            info.directories.sort(sortFunction);
-          }
-
-          document.getElementById('listing').innerHTML =
-                '<pre>' + prepareTable(info) + '</pre>';
-        }
-      })
-      .fail(function(error) {
-        console.error(error);
-        $('#listing').html('<strong>Error: ' + error + '</strong>');
-      });
+        listing_element.innerHTML =
+          '<pre>' + prepareTable(info) + '</pre>';
+      }
+    })
+    .catch(error => {
+      console.error(error);
+      listing_element.innerHTML =
+        '<strong>Error: ' + error + '</strong>';
+    });
 }
 
 function buildNavigation(info) {
@@ -170,18 +116,16 @@ function buildNavigation(info) {
   var root = '<a href="' + baseUrl + '">' + BUCKET_WEBSITE_URL + '</a> / ';
   if (info.prefix) {
     var processedPathSegments = '';
-    var content = $.map(info.prefix.split('/'), function(pathSegment) {
-      processedPathSegments =
-          processedPathSegments + encodeURIComponent(pathSegment) + '/';
-
+    var content = info.prefix.split('/').map(function(pathSegment) {
+      processedPathSegments += encodeURIComponent(pathSegment) + '/';
       var link = document.createElement('a');
       link.setAttribute('href', baseUrl + processedPathSegments.replace(/"/g, '&quot;'));
       link.innerText = pathSegment;
       return link.outerHTML;
     });
-    $('#navigation').html(root + content.join(' / '));
+    document.getElementById('navigation').innerHTML = root + content.join(' / ');
   } else {
-    $('#navigation').html(root);
+    document.getElementById('navigation').innerHTML = root;
   }
 }
 
@@ -228,53 +172,42 @@ function createS3QueryUrl(marker) {
 }
 
 function getInfoFromS3Data(xml) {
-  var prefix = $(xml.find('Prefix')[0]).text();
-  var files = $.map(xml.find('Contents'), function(item) {
-    item = $(item);
-    // clang-format off
+  var prefix = xml.querySelector('Prefix') ? xml.querySelector('Prefix').textContent : '';
+  var files = Array.from(xml.querySelectorAll('Contents')).map(function(item) {
     return {
-      Key: item.find('Key').text(),
-          LastModified: item.find('LastModified').text(),
-          Size: bytesToHumanReadable(item.find('Size').text()),
-          Type: 'file'
-    }
-    // clang-format on
+      Key: item.querySelector('Key').textContent,
+      LastModified: item.querySelector('LastModified').textContent,
+      Size: bytesToHumanReadable(item.querySelector('Size').textContent),
+      Type: 'file'
+    };
   });
   if (prefix && files[0] && files[0].Key == prefix) {
     files.shift();
   }
-  var directories = $.map(xml.find('CommonPrefixes'), function(item) {
-    item = $(item);
-    last_modified = '';
+  var directories = Array.from(xml.querySelectorAll('CommonPrefixes')).map(function(item) {
+    var last_modified = '';
     if (S3B_STAT_DIRS) {
-        http = new XMLHttpRequest();
-        http.open("HEAD",item.find('Prefix').text(),false);
-        http.send();
-        last_modified = (new Date(http.getResponseHeader("Last-Modified"))).toISOString();
+      http = new XMLHttpRequest();
+      http.open("HEAD", item.querySelector('Prefix').textContent, false);
+      http.send();
+      last_modified = new Date(http.getResponseHeader("Last-Modified")).toISOString();
     }
-    // clang-format off
     return {
-      Key: item.find('Prefix').text(),
-        LastModified: last_modified,
-        Size: 'dir',
-        Type: 'directory'
-    }
-    // clang-format on
+      Key: item.querySelector('Prefix').textContent,
+      LastModified: last_modified,
+      Size: 'dir',
+      Type: 'directory'
+    };
   });
-  if ($(xml.find('IsTruncated')[0]).text() == 'true') {
-    var nextMarker = $(xml.find('NextMarker')[0]).text();
-  } else {
-    var nextMarker = null;
-  }
-  // clang-format off
+  var nextMarker = xml.querySelector('IsTruncated').textContent === 'true' ?
+    xml.querySelector('NextMarker').textContent : null;
   return {
     files: files,
     directories: directories,
     prefix: prefix,
-    bucketname: $(xml.find('Name')).text(),
-    nextMarker: encodeURIComponent(nextMarker)
+    bucketname: xml.querySelector('Name').textContent,
+    nextMarker: nextMarker
   }
-  // clang-format on
 }
 
 // info is object like:
@@ -308,9 +241,8 @@ function prepareTable(info) {
         row = renderRow(item, cols);
     content.push(row + '\n');
   }
-
-  jQuery.each(files, function(idx, item) {
-    // strip off the prefix
+  // strip off the prefix
+  files.forEach(function(item) {
     item.keyText = item.Key.substring(prefix.length);
     if (item.Type === 'directory') {
       if (S3BL_IGNORE_PATH) {

--- a/test/index-non-s3.html
+++ b/test/index-non-s3.html
@@ -5,7 +5,6 @@
   <div id="navigation"></div>
   <div id="listing"></div>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
 <script type="text/javascript">
   var BUCKET_URL = 'http://data.openspending.org.s3-eu-west-1.amazonaws.com';
   var S3BL_IGNORE_PATH = true;

--- a/test/index.html
+++ b/test/index.html
@@ -5,7 +5,6 @@
   <div id="navigation"></div>
   <div id="listing"></div>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
 <script type="text/javascript">
   var BUCKET_URL = 'http://data.openspending.org.s3-eu-west-1.amazonaws.com';
 </script>


### PR DESCRIPTION
Native APIs available in modern(ish) browsers make possible to remove relatively easily the dependency on jQuery.

This reduces the amount of code needed to load the viewer.

The Array.prototype.includes polyfill has been removed since it is available on all browsers since ~ 2016.

No functional changes expected. I tried to stay as close as possible to the existing code.