### PR TITLE
Fix invalid NextMarker value

### DIFF
--- a/list.js
+++ b/list.js
@@ -262,7 +262,7 @@ function getInfoFromS3Data(xml) {
     // clang-format on
   });
   if ($(xml.find('IsTruncated')[0]).text() == 'true') {
-    var nextMarker = $(xml.find('NextMarker')[0]).text();
+    var nextMarker = xml.find('NextMarker').textContent
   } else {
     var nextMarker = null;
   }


### PR DESCRIPTION
Closes #134 

This PR basically fixes the nextmarker value extracted from the xml response.

Changes the value from `sub%2Fafg%2Frfh%2Fafgr4q202309d2.tif` to `sub/afg/rfh/afgr4q202309d2.tif`, removing the infinite loop when listing folders more than 1000 keys.